### PR TITLE
paramTypes in FindMethod()

### DIFF
--- a/StaticMemberDynamicWrapper/StaticMemberDynamicWrapper.cs
+++ b/StaticMemberDynamicWrapper/StaticMemberDynamicWrapper.cs
@@ -37,7 +37,7 @@ namespace StaticMemberDynamicWrapper
 
         public override Boolean TryInvokeMember(InvokeMemberBinder binder, Object[] args,
            out Object result) {
-            MethodInfo method = FindMethod(binder.Name, null);
+            MethodInfo method = FindMethod(binder.Name, args.Select(a => a.GetType()).ToArray());
             if (method == null) { result = null; return false; }
             result = method.Invoke(null, args);
             return true;


### PR DESCRIPTION
When calling FindMethod(), paramTypes must be args.Select(a => a.GetType()).ToArray(). From book sample project.